### PR TITLE
Add per-language pages and buttons for language navigation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -74,28 +74,32 @@ body {
   font-size: 0.95rem;
 }
 
-.language-nav {
-  display: flex;
+.language-switcher {
+  display: inline-flex;
   gap: 0.75rem;
   font-size: 0.95rem;
 }
 
-.language-nav a {
+.language-switcher button {
   color: var(--color-muted);
-  text-decoration: none;
-  padding: 0.35rem 0.75rem;
+  background: white;
+  border: 1px solid rgba(17, 63, 103, 0.25);
+  padding: 0.4rem 0.85rem;
   border-radius: 999px;
-  border: 1px solid transparent;
+  font: inherit;
+  cursor: pointer;
   transition: all 0.2s ease;
 }
 
-.language-nav a:hover,
-.language-nav a:focus {
+.language-switcher button:hover,
+.language-switcher button:focus {
   color: var(--color-primary);
-  border-color: rgba(17, 63, 103, 0.25);
+  border-color: var(--color-primary);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(17, 63, 103, 0.12);
 }
 
-.language-nav .active {
+.language-switcher .is-active {
   background: var(--color-primary);
   color: white;
   border-color: var(--color-primary);
@@ -329,7 +333,7 @@ body {
 
 .intro-columns {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1.5rem;
 }
 
@@ -360,6 +364,17 @@ body {
   margin: 0;
   color: var(--color-text);
   font-size: 1rem;
+}
+
+.intro-card a {
+  color: var(--color-secondary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.intro-card a:hover,
+.intro-card a:focus {
+  color: var(--color-accent);
 }
 
 .intro-card[lang="en"],

--- a/english.html
+++ b/english.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Levin Fisher Law Office | Commercial Litigation & Corporate Law</title>
+    <meta
+      name="description"
+      content="Levin Fisher is a boutique law office specialising in complex litigation, corporate and commercial law, venture capital and capital markets."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body dir="ltr" class="homepage">
+    <div class="page">
+      <header class="site-header">
+        <div class="brand">
+          <span class="logo" aria-hidden="true"></span>
+          <div class="brand-text">
+            <h1>Levin Fisher</h1>
+            <p>Law Office</p>
+          </div>
+        </div>
+        <nav class="language-switcher" aria-label="Language selection">
+          <button type="button" data-target="index.html" lang="he">עברית</button>
+          <button type="button" data-target="english.html" lang="en" class="is-active">English</button>
+          <button type="button" data-target="francais.html" lang="fr">Français</button>
+        </nav>
+      </header>
+
+      <div class="layout">
+        <nav class="side-nav" aria-label="Main navigation">
+          <button class="side-nav__toggle" aria-expanded="false" aria-controls="main-navigation">
+            Menu
+          </button>
+          <ul id="main-navigation">
+            <li><a href="#about">About the firm</a></li>
+            <li><a href="#partners">Founding partners</a></li>
+            <li><a href="#expertise">Practice areas</a></li>
+            <li><a href="#articles">Insights</a></li>
+            <li><a href="#contact">Contact</a></li>
+          </ul>
+        </nav>
+
+        <main class="content">
+          <section class="hero" aria-labelledby="hero-title">
+            <div class="hero__overlay"></div>
+            <div class="hero__inner">
+              <h2 id="hero-title">Levin Fisher - Law Firm</h2>
+              <p>
+                Levin Fisher is a boutique law firm specialising in complex litigation and commercial and
+                corporate matters. We build strategic, tailor-made legal solutions that support our clients'
+                business ambitions in Israel and abroad.
+              </p>
+            </div>
+            <div class="hero__slider" aria-hidden="true">
+              <div class="hero__slide hero__slide--one"></div>
+              <div class="hero__slide hero__slide--two"></div>
+              <div class="hero__slide hero__slide--three"></div>
+              <div class="hero__slide hero__slide--one" aria-hidden="true"></div>
+            </div>
+          </section>
+
+          <section class="partners" id="partners" aria-labelledby="partners-title">
+            <div class="partners__header">
+              <h2 id="partners-title">Founding partners</h2>
+              <p>
+                The founding partners lead every engagement personally, combining decades of courtroom
+                experience with a deep understanding of business strategy and regulation.
+              </p>
+            </div>
+            <div class="partners__grid">
+              <article class="partner-card">
+                <figure class="partner-card__media">
+                  <img
+                    src="https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=800&q=80"
+                    alt="Adv. Michal Levin"
+                    loading="lazy"
+                  />
+                </figure>
+                <div class="partner-card__body">
+                  <h3>Adv. Michal Levin</h3>
+                  <p class="partner-card__title">Founding Partner &amp; Head of Litigation</p>
+                  <p>
+                    An expert in managing complex civil and commercial proceedings before Israeli courts and
+                    arbitration panels. Represents companies and entrepreneurs in shareholder disputes,
+                    derivative actions and special litigation committees.
+                  </p>
+                  <ul>
+                    <li>Complex commercial and civil litigation</li>
+                    <li>Representation of boards and controlling shareholders</li>
+                    <li>Strategic guidance throughout dispute resolution</li>
+                  </ul>
+                </div>
+              </article>
+
+              <article class="partner-card">
+                <figure class="partner-card__media">
+                  <img
+                    src="https://images.unsplash.com/photo-1522075469751-3a6694fb2f61?auto=format&fit=crop&w=800&q=80"
+                    alt="Adv. Ori Fisher"
+                    loading="lazy"
+                  />
+                </figure>
+                <div class="partner-card__body">
+                  <h3>Adv. Ori Fisher</h3>
+                  <p class="partner-card__title">Founding Partner &amp; Head of Corporate</p>
+                  <p>
+                    Advises public and private companies on sophisticated transactions in Israel and abroad, with
+                    extensive experience in corporate governance, offerings and regulatory compliance.
+                  </p>
+                  <ul>
+                    <li>Corporate and commercial law</li>
+                    <li>Counsel on mergers and acquisitions</li>
+                    <li>Capital markets offerings and restructurings</li>
+                  </ul>
+                </div>
+              </article>
+            </div>
+          </section>
+
+          <section class="intro-columns">
+            <article class="intro-card" id="about">
+              <header>
+                <h3>
+                  <span class="flag flag--us" aria-hidden="true"></span>
+                  About the firm
+                </h3>
+              </header>
+              <p>
+                Levin Fisher is a leading boutique law firm specialising in complex litigation (civil,
+                commercial, corporate and white-collar criminal law) and in commercial law, corporate law,
+                venture capital, securities and capital markets.
+              </p>
+              <p>
+                The firm has earned a reputation among its clients in Israel and abroad, as well as within the
+                legal community, for handling each matter with creativity, depth and exceptional legal
+                expertise.
+              </p>
+            </article>
+
+            <article class="intro-card" id="expertise">
+              <header>
+                <h3>
+                  <span class="flag flag--il" aria-hidden="true"></span>
+                  Practice areas
+                </h3>
+              </header>
+              <p>
+                Our team handles high-stakes commercial litigation, shareholder disputes, derivative actions and
+                arbitration proceedings, alongside ongoing advice on complex transactions.
+              </p>
+              <p>
+                We partner with clients across the technology, finance and infrastructure sectors, providing
+                counsel on regulatory strategy, corporate governance and risk management.
+              </p>
+            </article>
+
+            <article class="intro-card" id="articles">
+              <header>
+                <h3>
+                  <span class="flag flag--us" aria-hidden="true"></span>
+                  Insights
+                </h3>
+              </header>
+              <p>
+                The partners regularly publish articles and lectures on litigation strategy, directors' duties and
+                developments in the Israeli and international capital markets.
+              </p>
+              <p>
+                To receive updates about new publications and events, follow our LinkedIn page or contact us to be
+                added to our mailing list.
+              </p>
+            </article>
+
+            <article class="intro-card" id="contact">
+              <header>
+                <h3>
+                  <span class="flag flag--il" aria-hidden="true"></span>
+                  Contact
+                </h3>
+              </header>
+              <p>
+                12 Herzl Street, Tel Aviv | Tel: +972-3-555-1234
+              </p>
+              <p>
+                Email: <a href="mailto:info@levin-fisher.com">info@levin-fisher.com</a>
+              </p>
+              <p>
+                We welcome enquiries in Hebrew, English and French and will respond within one business day.
+              </p>
+            </article>
+          </section>
+        </main>
+      </div>
+
+      <footer class="site-footer">
+        <p>© 2024 Levin Fisher Law Office</p>
+        <p class="credit">
+          Website inspired by the original design of
+          <a href="https://www.levin-fisher.com/">Levin Fisher</a>
+        </p>
+      </footer>
+    </div>
+    <script src="js/main.js"></script>
+  </body>
+</html>

--- a/francais.html
+++ b/francais.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cabinet Levin Fisher | Contentieux commercial & droit des affaires</title>
+    <meta
+      name="description"
+      content="Levin Fisher est un cabinet boutique spécialisé en contentieux civils et commerciaux complexes, droit des sociétés, capital-investissement et marchés de capitaux."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body dir="ltr" class="homepage">
+    <div class="page">
+      <header class="site-header">
+        <div class="brand">
+          <span class="logo" aria-hidden="true"></span>
+          <div class="brand-text">
+            <h1>Levin Fisher</h1>
+            <p>Cabinet d'avocats</p>
+          </div>
+        </div>
+        <nav class="language-switcher" aria-label="Sélection de la langue">
+          <button type="button" data-target="index.html" lang="he">עברית</button>
+          <button type="button" data-target="english.html" lang="en">English</button>
+          <button type="button" data-target="francais.html" lang="fr" class="is-active">Français</button>
+        </nav>
+      </header>
+
+      <div class="layout">
+        <nav class="side-nav" aria-label="Navigation principale">
+          <button class="side-nav__toggle" aria-expanded="false" aria-controls="main-navigation">
+            Menu
+          </button>
+          <ul id="main-navigation">
+            <li><a href="#about">À propos du cabinet</a></li>
+            <li><a href="#partners">Associés fondateurs</a></li>
+            <li><a href="#expertise">Domaines d'expertise</a></li>
+            <li><a href="#articles">Publications</a></li>
+            <li><a href="#contact">Contact</a></li>
+          </ul>
+        </nav>
+
+        <main class="content">
+          <section class="hero" aria-labelledby="hero-title">
+            <div class="hero__overlay"></div>
+            <div class="hero__inner">
+              <h2 id="hero-title">Levin Fisher - Cabinet d'avocats</h2>
+              <p>
+                Le cabinet Levin Fisher est un cabinet boutique de premier plan, dédié aux contentieux civils et
+                commerciaux complexes ainsi qu'au conseil en droit des affaires pour des sociétés israéliennes et
+                internationales.
+              </p>
+            </div>
+            <div class="hero__slider" aria-hidden="true">
+              <div class="hero__slide hero__slide--one"></div>
+              <div class="hero__slide hero__slide--two"></div>
+              <div class="hero__slide hero__slide--three"></div>
+              <div class="hero__slide hero__slide--one" aria-hidden="true"></div>
+            </div>
+          </section>
+
+          <section class="partners" id="partners" aria-labelledby="partners-title">
+            <div class="partners__header">
+              <h2 id="partners-title">Associés fondateurs</h2>
+              <p>
+                Les associés fondateurs suivent personnellement chaque dossier et allient une expertise
+                contentieuse approfondie à une compréhension fine des enjeux commerciaux et réglementaires.
+              </p>
+            </div>
+            <div class="partners__grid">
+              <article class="partner-card">
+                <figure class="partner-card__media">
+                  <img
+                    src="https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=800&q=80"
+                    alt="Avocate Michal Levin"
+                    loading="lazy"
+                  />
+                </figure>
+                <div class="partner-card__body">
+                  <h3>Avocate Michal Levin</h3>
+                  <p class="partner-card__title">Associée fondatrice &amp; Responsable du contentieux</p>
+                  <p>
+                    Spécialiste de la gestion de contentieux civils et commerciaux complexes devant les tribunaux
+                    israéliens et en arbitrage. Représente des sociétés et dirigeants dans les litiges entre
+                    actionnaires, actions dérivées et comités spéciaux de litige.
+                  </p>
+                  <ul>
+                    <li>Contentieux civil et commercial complexe</li>
+                    <li>Représentation des conseils d'administration et actionnaires de contrôle</li>
+                    <li>Accompagnement stratégique des modes de résolution des litiges</li>
+                  </ul>
+                </div>
+              </article>
+
+              <article class="partner-card">
+                <figure class="partner-card__media">
+                  <img
+                    src="https://images.unsplash.com/photo-1522075469751-3a6694fb2f61?auto=format&fit=crop&w=800&q=80"
+                    alt="Avocat Ori Fisher"
+                    loading="lazy"
+                  />
+                </figure>
+                <div class="partner-card__body">
+                  <h3>Avocat Ori Fisher</h3>
+                  <p class="partner-card__title">Associé fondateur &amp; Responsable du droit des affaires</p>
+                  <p>
+                    Conseille des sociétés cotées et privées sur des opérations complexes en Israël et à
+                    l'international, avec une grande expérience en gouvernance d'entreprise, introductions en
+                    bourse et conformité réglementaire.
+                  </p>
+                  <ul>
+                    <li>Droit des sociétés et commercial</li>
+                    <li>Conseil en fusions et acquisitions</li>
+                    <li>Introductions en bourse et restructurations des marchés de capitaux</li>
+                  </ul>
+                </div>
+              </article>
+            </div>
+          </section>
+
+          <section class="intro-columns">
+            <article class="intro-card" id="about">
+              <header>
+                <h3>
+                  <span class="flag flag--fr" aria-hidden="true"></span>
+                  À propos du cabinet
+                </h3>
+              </header>
+              <p>
+                Levin Fisher est un cabinet d'avocats boutique, expert en contentieux complexes (civil, commercial,
+                droit des sociétés et droit pénal des affaires) ainsi qu'en conseil en droit commercial, capital-
+                investissement, valeurs mobilières et marchés de capitaux.
+              </p>
+              <p>
+                Depuis sa création, le cabinet offre un accompagnement personnalisé et une approche créative, avec
+                un niveau d'expertise juridique élevé reconnu par ses clients en Israël et à l'étranger.
+              </p>
+            </article>
+
+            <article class="intro-card" id="expertise">
+              <header>
+                <h3>
+                  <span class="flag flag--il" aria-hidden="true"></span>
+                  Domaines d'expertise
+                </h3>
+              </header>
+              <p>
+                Nous intervenons dans les litiges commerciaux à fort enjeu, les différends entre actionnaires,
+                l'arbitrage et les procédures collectives, tout en accompagnant les transactions stratégiques et les
+                levées de fonds.
+              </p>
+              <p>
+                Notre équipe conseille des entreprises des secteurs technologique, financier et industriel sur la
+                gouvernance, la conformité et la gestion des risques.
+              </p>
+            </article>
+
+            <article class="intro-card" id="articles">
+              <header>
+                <h3>
+                  <span class="flag flag--fr" aria-hidden="true"></span>
+                  Publications
+                </h3>
+              </header>
+              <p>
+                Les associés publient régulièrement des analyses sur la stratégie contentieuse, les obligations des
+                dirigeants et l'évolution des marchés financiers israéliens et internationaux.
+              </p>
+              <p>
+                Pour recevoir nos publications et invitations, suivez-nous sur LinkedIn ou contactez-nous pour être
+                ajouté à notre liste de diffusion.
+              </p>
+            </article>
+
+            <article class="intro-card" id="contact">
+              <header>
+                <h3>
+                  <span class="flag flag--il" aria-hidden="true"></span>
+                  Contact
+                </h3>
+              </header>
+              <p>
+                12, rue Herzl, Tel Aviv | Tél. : +972-3-555-1234
+              </p>
+              <p>
+                Email : <a href="mailto:info@levin-fisher.com">info@levin-fisher.com</a>
+              </p>
+              <p>
+                Nous répondons aux demandes en hébreu, en anglais et en français sous un jour ouvrable.
+              </p>
+            </article>
+          </section>
+        </main>
+      </div>
+
+      <footer class="site-footer">
+        <p>© 2024 Cabinet d'avocats Levin Fisher</p>
+        <p class="credit">
+          Site inspiré par la conception originale de
+          <a href="https://www.levin-fisher.com/">Levin Fisher</a>
+        </p>
+      </footer>
+    </div>
+    <script src="js/main.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -26,10 +26,10 @@
             <p>משרד עורכי דין</p>
           </div>
         </div>
-        <nav class="language-nav" aria-label="בחירת שפה">
-          <a href="#he" class="active">עברית</a>
-          <a href="#en" lang="en">English</a>
-          <a href="#fr" lang="fr">Français</a>
+        <nav class="language-switcher" aria-label="בחירת שפה">
+          <button type="button" data-target="index.html" lang="he" class="is-active">עברית</button>
+          <button type="button" data-target="english.html" lang="en">English</button>
+          <button type="button" data-target="francais.html" lang="fr">Français</button>
         </nav>
       </header>
 
@@ -142,46 +142,6 @@
                 לעורכי הדין שלנו ניסיון בינלאומי עשיר בעבודה משפטית ועסקית בארה"ב ובעסקאות
                 בינלאומיות הכוללות מרכיב זר (Cross Border Litigation).
               </p>
-            </article>
-
-            <article class="intro-card" id="en" lang="en" dir="ltr">
-              <header>
-                <h3>
-                  <span class="flag flag--us" aria-hidden="true"></span>
-                  About the firm
-                </h3>
-              </header>
-              <p>
-                Levin Fisher is a leading boutique law firm specializing in complex litigation (civil,
-                commercial, corporate and white-collar criminal law) and in commercial law, corporate law,
-                venture capital, securities and capital markets.
-              </p>
-              <p>
-                The firm has earned a reputation among its clients in Israel and abroad, as well as in the
-                legal community, for handling each matter with creativity, depth and exceptional legal
-                expertise.
-              </p>
-              <p class="cta"><a href="#" hreflang="en">Read more in English</a></p>
-            </article>
-
-            <article class="intro-card" id="fr" lang="fr" dir="ltr">
-              <header>
-                <h3>
-                  <span class="flag flag--fr" aria-hidden="true"></span>
-                  À propos du cabinet
-                </h3>
-              </header>
-              <p>
-                Levin Fisher est un cabinet d'avocats boutique, expert en contentieux complexes (civil,
-                commercial, droit des sociétés et droit pénal des affaires) ainsi qu'en conseil en droit
-                commercial, droit des sociétés, capital-investissement, valeurs mobilières et marchés de
-                capitaux.
-              </p>
-              <p>
-                Depuis sa création, le cabinet accompagne personnellement chacun de ses clients et offre une
-                approche créative et innovante avec un niveau d'expertise juridique élevé.
-              </p>
-              <p class="cta"><a href="#" hreflang="fr">Lire en français</a></p>
             </article>
           </section>
         </main>

--- a/js/main.js
+++ b/js/main.js
@@ -2,12 +2,30 @@ document.addEventListener('DOMContentLoaded', () => {
   const toggle = document.querySelector('.side-nav__toggle');
   const list = document.querySelector('.side-nav ul');
 
-  if (!toggle || !list) {
-    return;
+  if (toggle && list) {
+    toggle.addEventListener('click', () => {
+      const isOpen = list.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    });
   }
 
-  toggle.addEventListener('click', () => {
-    const isOpen = list.classList.toggle('open');
-    toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  const languageButtons = document.querySelectorAll('.language-switcher button[data-target]');
+
+  languageButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const target = button.dataset.target;
+
+      if (!target) {
+        return;
+      }
+
+      const currentPath = window.location.pathname.split('/').pop() || 'index.html';
+
+      if (currentPath === target) {
+        return;
+      }
+
+      window.location.href = target;
+    });
   });
 });


### PR DESCRIPTION
## Summary
- replace the language links on the Hebrew homepage with buttons that switch between languages
- add dedicated English and French pages with localized content and shared styling
- update shared styles and scripts to support the new language switcher and responsive layouts

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d96d0a9af08325bbab1170de6af248