### PR TITLE
Remove language flags from intro cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -399,28 +399,6 @@ body {
   border-color: var(--color-accent);
 }
 
-.flag {
-  width: 36px;
-  height: 24px;
-  display: inline-block;
-  border-radius: 4px;
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-  background-size: cover;
-  background-position: center;
-}
-
-.flag--il {
-  background-image: url('https://upload.wikimedia.org/wikipedia/commons/d/d4/Flag_of_Israel.svg');
-}
-
-.flag--us {
-  background-image: url('https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg');
-}
-
-.flag--fr {
-  background-image: url('https://upload.wikimedia.org/wikipedia/en/c/c3/Flag_of_France.svg');
-}
-
 .site-footer {
   background: #0b1f33;
   color: rgba(255, 255, 255, 0.8);

--- a/english.html
+++ b/english.html
@@ -127,10 +127,7 @@
           <section class="intro-columns">
             <article class="intro-card" id="about">
               <header>
-                <h3>
-                  <span class="flag flag--us" aria-hidden="true"></span>
-                  About the firm
-                </h3>
+                <h3>About the firm</h3>
               </header>
               <p>
                 Levin Fisher is a leading boutique law firm specialising in complex litigation (civil,
@@ -146,10 +143,7 @@
 
             <article class="intro-card" id="expertise">
               <header>
-                <h3>
-                  <span class="flag flag--il" aria-hidden="true"></span>
-                  Practice areas
-                </h3>
+                <h3>Practice areas</h3>
               </header>
               <p>
                 Our team handles high-stakes commercial litigation, shareholder disputes, derivative actions and
@@ -163,10 +157,7 @@
 
             <article class="intro-card" id="articles">
               <header>
-                <h3>
-                  <span class="flag flag--us" aria-hidden="true"></span>
-                  Insights
-                </h3>
+                <h3>Insights</h3>
               </header>
               <p>
                 The partners regularly publish articles and lectures on litigation strategy, directors' duties and
@@ -180,10 +171,7 @@
 
             <article class="intro-card" id="contact">
               <header>
-                <h3>
-                  <span class="flag flag--il" aria-hidden="true"></span>
-                  Contact
-                </h3>
+                <h3>Contact</h3>
               </header>
               <p>
                 12 Herzl Street, Tel Aviv | Tel: +972-3-555-1234

--- a/francais.html
+++ b/francais.html
@@ -128,10 +128,7 @@
           <section class="intro-columns">
             <article class="intro-card" id="about">
               <header>
-                <h3>
-                  <span class="flag flag--fr" aria-hidden="true"></span>
-                  À propos du cabinet
-                </h3>
+                <h3>À propos du cabinet</h3>
               </header>
               <p>
                 Levin Fisher est un cabinet d'avocats boutique, expert en contentieux complexes (civil, commercial,
@@ -146,10 +143,7 @@
 
             <article class="intro-card" id="expertise">
               <header>
-                <h3>
-                  <span class="flag flag--il" aria-hidden="true"></span>
-                  Domaines d'expertise
-                </h3>
+                <h3>Domaines d'expertise</h3>
               </header>
               <p>
                 Nous intervenons dans les litiges commerciaux à fort enjeu, les différends entre actionnaires,
@@ -164,10 +158,7 @@
 
             <article class="intro-card" id="articles">
               <header>
-                <h3>
-                  <span class="flag flag--fr" aria-hidden="true"></span>
-                  Publications
-                </h3>
+                <h3>Publications</h3>
               </header>
               <p>
                 Les associés publient régulièrement des analyses sur la stratégie contentieuse, les obligations des
@@ -181,10 +172,7 @@
 
             <article class="intro-card" id="contact">
               <header>
-                <h3>
-                  <span class="flag flag--il" aria-hidden="true"></span>
-                  Contact
-                </h3>
+                <h3>Contact</h3>
               </header>
               <p>
                 12, rue Herzl, Tel Aviv | Tél. : +972-3-555-1234

--- a/index.html
+++ b/index.html
@@ -125,10 +125,7 @@
           <section class="intro-columns">
             <article class="intro-card" id="about">
               <header>
-                <h3>
-                  <span class="flag flag--il" aria-hidden="true"></span>
-                  על המשרד
-                </h3>
+                <h3>על המשרד</h3>
               </header>
               <p>
                 משרד עורכי הדין לוין פישר הינו משרד בוטיק מוביל, המתמחה בליטיגציה מורכבת –


### PR DESCRIPTION
## Summary
- remove flag icon spans from the intro card headers across Hebrew, English, and French pages
- delete unused CSS for the flag backgrounds now that the icons are gone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da264037b48325a6c371bda45916ce